### PR TITLE
Feature: use libcjson

### DIFF
--- a/.github/workflows/c-build.yml
+++ b/.github/workflows/c-build.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install libs
-      run: sudo apt install libjson-c-dev libcurl4-openssl-dev
+      run: sudo apt update && sudo apt install libcjson-dev libcurl4-openssl-dev
     - name: Build
       run: make all
     - name: Run tests

--- a/makefile
+++ b/makefile
@@ -63,7 +63,7 @@ TST = $(wildcard $(TSTD)/*.c) $(wildcard $(TSTD)/**/*.c)
 OBJ = $(patsubst $(SRCD)/%.c,$(OBJD)/$(TARGET)/%.o,$(SRC))
 OBT = $(patsubst $(SRCD)/%.c,$(OBJD)/$(TARGET).tests/%.o,$(SRC)) $(patsubst $(TSTD)/%.c,$(OBJD)/$(TARGET).tests/%.test.o,$(TST))
 
-_LDFLAGS = -lcurl -ljson-c
+_LDFLAGS = -lcurl -lcjson
 _CFLAGS_LOG = -Wall -Wextra -pedantic -Wpedantic
 _CFLAGS_DEFINES = -Isrc/ -D _DEFAULT_SOURCE
 _STD=c99

--- a/src/include/matrix-bot.h
+++ b/src/include/matrix-bot.h
@@ -10,14 +10,14 @@
 #define __XdAqsf9F_matrix_bot_h
 
 #include <sys/types.h>
-#include <json-c/json.h>
+#include <cjson/cJSON.h>
 
 #include "matrix-client.h"
 
 typedef struct MatrixBot MatrixBot;
 
 typedef struct {
-  json_object *raw_json;
+  cJSON *raw_json;
 
   const char *type;
   const char *sender;
@@ -25,7 +25,7 @@ typedef struct {
   const char *room_id;
   u_int64_t  origin_server_ts;
 
-  json_object *content;
+  cJSON *content;
 } MatrixEvent;
 
 typedef struct {
@@ -65,15 +65,15 @@ typedef struct {
   char error[256];
 } MatrixBotLoopResult;
 
-MatrixEvent matrixbot_event_from(json_object *json, const char *room_id);
-MatrixEventMessage matrixbot_message_from(json_object *json);
-MatrixEventMessageEdit matrixbot_messageedit_from(json_object *json);
+MatrixEvent matrixbot_event_from(cJSON *json, const char *room_id);
+MatrixEventMessage matrixbot_message_from(cJSON *json);
+MatrixEventMessageEdit matrixbot_messageedit_from(cJSON *json);
 
 MatrixBot           matrixbot_new(const char *homeserver, const char *access_token);
 __attribute__((warn_unused_result))
 MatrixBotLoopResult matrixbot_loop(MatrixBot *bot);
 
-#define matrixbot_qsync(bot) json_object_put(matrix_sync(&bot.client, 0))
+#define matrixbot_qsync(bot) cJSON_Delete(matrix_sync(&bot.client, 0))
 
 __attribute__((warn_unused_result))
 MatrixSendResult matrixbot_send(MatrixBotContext ctx, const char *message);

--- a/src/include/matrix-client.h
+++ b/src/include/matrix-client.h
@@ -9,8 +9,7 @@
 #ifndef __uoQ7JFxV_matrix_client_h
 #define __uoQ7JFxV_matrix_client_h
 
-#include <json-c/json.h>
-#include <wchar.h>
+#include <cjson/cJSON.h>
 
 #include "matrix-defines.h"
 
@@ -28,7 +27,7 @@ typedef struct MatrixNode {
 } MatrixNode;
 
 typedef struct {
-  json_object *raw_json;
+  cJSON *raw_json;
 
   const char *errcode;
   const char *error;
@@ -39,7 +38,7 @@ typedef struct {
 #define matrix_newnode(_key, _value, _flags, _next) \
   ((MatrixNode){ .key = _key, .value = _value, .flags = _flags, .next = _next })
 #define matrixsendres_free(res) \
-  json_object_put(res.raw_json)
+  cJSON_Delete(res.raw_json)
 
 /*
  * Stringify matrix nodes into json object.
@@ -56,7 +55,7 @@ void matrixnode_free(MatrixNode chain);
 /*
  * Send request to API
  */
-__attribute__((nonnull(1, 2, 3))) json_object* matrix_request(
+__attribute__((nonnull(1, 2, 3))) cJSON* matrix_request(
     const MatrixClient *client,
     const char *method,
     const char *path,
@@ -68,7 +67,7 @@ __attribute__((nonnull(1, 2, 3))) json_object* matrix_request(
  * Sync events via sending request to API
  * and modify MatrixClient
  */
-__attribute__((nonnull(1))) json_object* matrix_sync(
+__attribute__((nonnull(1))) cJSON* matrix_sync(
     MatrixClient *client,
     const MatrixNode *query
     );

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,3 @@
-#include <json-c/json_object.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -10,6 +9,7 @@
 #include <signal.h>
 
 #include "include/matrix-bot.h"
+#include "include/matrix-client.h"
 
 #ifndef MATRIXBOT_DEFAULTHS
 #define MATRIXBOT_DEFAULTHS "matrix-client.matrix.org"


### PR DESCRIPTION
```
Feature: use libcjson
---------------------
Some times on matrix_sync() hs returns >80k of bytes data.
libjson-c can't handle it without SIGABRT.

1. Possible Bugs
----------------
* matrix-bot.c: matrixbot_event_from()
    origin_server_ts parses as double, but it u64
    <33> if (json)
    <34>   res.origin_server_ts = (u_int64_t)json->valuedouble;
* matrix-bot.c: matrixbot_[q]{send,reply}[f]()
    I used sed to change libjson-c to libcjson (lol...)
```